### PR TITLE
fix: Configurable OAuth2 login page security

### DIFF
--- a/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/AuthorizationProperties.java
+++ b/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/AuthorizationProperties.java
@@ -48,6 +48,8 @@ public class AuthorizationProperties {
 
 	private List<String> authenticatedPaths = new ArrayList<>();
 
+	private List<String> anonymousPaths = new ArrayList<>(0);
+
 	/**
 	 * Role-mapping configuration per OAuth2 provider.
 	 */
@@ -129,6 +131,14 @@ public class AuthorizationProperties {
 
 	public void setAuthenticatedPaths(List<String> authenticatedPaths) {
 		this.authenticatedPaths = authenticatedPaths;
+	}
+
+	public List<String> getAnonymousPaths() {
+		return anonymousPaths;
+	}
+
+	public void setAnonymousPaths(List<String> anonymousPaths) {
+		this.anonymousPaths = anonymousPaths;
 	}
 
 	public void setDefaultProviderId(String defaultProviderId) {

--- a/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -216,16 +216,22 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 			http.addFilter(basicAuthenticationFilter);
 		}
 
-		//this.authorizationProperties.getAuthenticatedPaths().add("/");
-		//this.authorizationProperties.getAuthenticatedPaths().add(this.authorizationProperties.getDashboardUrl());
-		//this.authorizationProperties.getAuthenticatedPaths().add(dashboard(authorizationProperties, "/**"));
+		// Anonymous paths for the login page
+		this.authorizationProperties.getAnonymousPaths().add(authorizationProperties.getLoginUrl());
 
+		// All paths should be available only for authenticated users
+		this.authorizationProperties.getAuthenticatedPaths().add("/");
+		this.authorizationProperties.getAuthenticatedPaths().add(this.authorizationProperties.getDashboardUrl());
+		this.authorizationProperties.getAuthenticatedPaths().add(dashboard(authorizationProperties, "/*/**"));
+
+		// Permit for all users as the visibility is managed through roles
 		this.authorizationProperties.getPermitAllPaths().add(this.authorizationProperties.getDashboardUrl());
 		this.authorizationProperties.getPermitAllPaths().add(dashboard(authorizationProperties, "/**"));
-		this.authorizationProperties.getPermitAllPaths().add(authorizationProperties.getLoginUrl());
 
 		ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry security =
 				http.authorizeRequests()
+						.antMatchers(this.authorizationProperties.getAnonymousPaths().toArray(new String[0]))
+						.anonymous()
 						.antMatchers(this.authorizationProperties.getPermitAllPaths().toArray(new String[0]))
 						.permitAll()
 						.antMatchers(this.authorizationProperties.getAuthenticatedPaths().toArray(new String[0]))

--- a/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
+++ b/spring-cloud-common-security-config/spring-cloud-common-security-config-web/src/main/java/org/springframework/cloud/common/security/OAuthSecurityConfiguration.java
@@ -222,7 +222,7 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 		// All paths should be available only for authenticated users
 		this.authorizationProperties.getAuthenticatedPaths().add("/");
 		this.authorizationProperties.getAuthenticatedPaths().add(this.authorizationProperties.getDashboardUrl());
-		this.authorizationProperties.getAuthenticatedPaths().add(dashboard(authorizationProperties, "/*/**"));
+		this.authorizationProperties.getAuthenticatedPaths().add(dashboard(authorizationProperties, "/**"));
 
 		// Permit for all users as the visibility is managed through roles
 		this.authorizationProperties.getPermitAllPaths().add(this.authorizationProperties.getDashboardUrl());
@@ -230,12 +230,12 @@ public class OAuthSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 		ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry security =
 				http.authorizeRequests()
-						.antMatchers(this.authorizationProperties.getAnonymousPaths().toArray(new String[0]))
-						.anonymous()
+						.antMatchers(this.authorizationProperties.getAuthenticatedPaths().toArray(new String[0]))
+						.authenticated()
 						.antMatchers(this.authorizationProperties.getPermitAllPaths().toArray(new String[0]))
 						.permitAll()
-						.antMatchers(this.authorizationProperties.getAuthenticatedPaths().toArray(new String[0]))
-						.authenticated();
+						.antMatchers(this.authorizationProperties.getAnonymousPaths().toArray(new String[0]))
+						.anonymous();
 		security = SecurityConfigUtils.configureSimpleSecurity(security, this.authorizationProperties);
 		security.anyRequest().denyAll();
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/security/SecurityController.java
@@ -85,7 +85,7 @@ public class SecurityController {
 
 		if (authenticationEnabled && SecurityContextHolder.getContext() != null) {
 			final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-			if (!(authentication instanceof AnonymousAuthenticationToken)) {
+			if (!(authentication instanceof AnonymousAuthenticationToken) && authentication != null) {
 				securityInfo.setAuthenticated(authentication.isAuthenticated());
 				securityInfo.setUsername(authentication.getName());
 


### PR DESCRIPTION
I just saw that the spring-cloud-dataflow-ui checks if the user has authenticated and is logged in.

See:
https://github.com/spring-cloud/spring-cloud-dataflow-ui/blob/main/ui/src/app/app.component.ts#L12

and

https://github.com/spring-cloud/spring-cloud-dataflow-ui/blob/main/ui/src/app/security/service/security.service.ts

So I adjusted the httpSecurity as you can see in the `Files changed`